### PR TITLE
adjust to 5.1 changes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,6 +27,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install yarn
     - run: |
-        XTERMJS=master IMAGEADDON=${{ github.head_ref || github.ref_name }} ./bootstrap.sh
+        XTERMJS=5.1.0 IMAGEADDON=${{ github.head_ref || github.ref_name }} ./bootstrap.sh
     - run: cd xterm-addon-image/xterm.js && yarn test
     - run: cd xterm-addon-image/xterm.js && yarn test-api-chromium --headless

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,6 +27,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install yarn
     - run: |
-        XTERMJS=5.0.0 IMAGEADDON=${{ github.head_ref || github.ref_name }} ./bootstrap.sh
+        XTERMJS=master IMAGEADDON=${{ github.head_ref || github.ref_name }} ./bootstrap.sh
     - run: cd xterm-addon-image/xterm.js && yarn test
     - run: cd xterm-addon-image/xterm.js && yarn test-api-chromium --headless

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install --save xterm-addon-image
 - 0.1.x - compatible to xterm.js 4.16.0 - 4.19.0
 - 0.2.0 - compatible to xterm.js 5.0.0
 - 0.3.0 - compatible to xterm.js 5.0.0
+- 0.3.1 - compatible to xterm.js 5.1.0
 
 
 ### Clone & Build
@@ -26,7 +27,7 @@ The addon integrates tightly with the xterm.js base repo, esp. for tests and the
 To properly set up all needed resources see `bootstrap.sh` or run it directly with
 
 ```bash
-curl -s https://raw.githubusercontent.com/jerch/xterm-addon-image/master/bootstrap.sh | XTERMJS=5.0.0 IMAGEADDON=master bash
+curl -s https://raw.githubusercontent.com/jerch/xterm-addon-image/master/bootstrap.sh | XTERMJS=5.1.0 IMAGEADDON=master bash
 ```
 
 The addon sources and npm package definition reside under `addons/xterm-addon-image`.
@@ -210,6 +211,7 @@ Sixel support and image handling in xterm.js is considered beta quality.
 
 ### Changelog
 
+- 0.3.1 compat release for xterm.js 5.1.0
 - 0.3.0 important change: worker removed from addon
 - 0.2.0 compat release for xterm.js 5.0.0
 - 0.1.3 bugfix: avoid striping

--- a/overwrite/demo/start.js
+++ b/overwrite/demo/start.js
@@ -113,7 +113,7 @@ function generateAddonWorker(addonName) {
 
 const compiler = webpack([
   clientConfig,
-  generateAddonWorker('image')
+  // generateAddonWorker('image')
 ]);
 
 compiler.watch({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-addon-image",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Joerg Breitbart <j.breitbart@netzkolchose.de>",
   "main": "lib/xterm-addon-image.js",
   "types": "typings/xterm-addon-image.d.ts",
@@ -13,7 +13,7 @@
     "prepublishOnly": "npm run package"
   },
   "peerDependencies": {
-    "xterm": "^5.0.0"
+    "xterm": "~5.1.0"
   },
   "devDependencies": {
     "png-ts": "^0.0.3",

--- a/src/ImageAddon.ts
+++ b/src/ImageAddon.ts
@@ -271,8 +271,8 @@ export class ImageAddon implements ITerminalAddon {
       switch (params[1]) {
         // we only implement read and read_max here
         case GaAction.READ:
-          let width = this._renderer?.dimensions?.canvasWidth;
-          let height = this._renderer?.dimensions?.canvasHeight;
+          let width = this._renderer?.dimensions?.css.canvas.width;
+          let height = this._renderer?.dimensions?.css.canvas.height;
           if (!width || !height) {
             // for some reason we have no working image renderer
             // --> fallback to default cell size

--- a/src/ImageRenderer.ts
+++ b/src/ImageRenderer.ts
@@ -125,8 +125,8 @@ export class ImageRenderer implements IDisposable {
    */
   public get cellSize(): ICellSize {
     return {
-      width: this.dimensions?.actualCellWidth || -1,
-      height: this.dimensions?.actualCellHeight || -1
+      width: this.dimensions?.css.cell.width || -1,
+      height: this.dimensions?.css.cell.height || -1
     };
   }
 
@@ -136,9 +136,9 @@ export class ImageRenderer implements IDisposable {
   public clearLines(start: number, end: number): void {
     this._ctx?.clearRect(
       0,
-      start * (this.dimensions?.actualCellHeight || 0),
-      this.dimensions?.canvasWidth || 0,
-      (++end - start) * (this.dimensions?.actualCellHeight || 0)
+      start * (this.dimensions?.css.cell.height || 0),
+      this.dimensions?.css.canvas.width || 0,
+      (++end - start) * (this.dimensions?.css.cell.height || 0)
     );
   }
 
@@ -253,9 +253,9 @@ export class ImageRenderer implements IDisposable {
     if (!this.canvas) {
       return;
     }
-    if (this.canvas.width !== this.dimensions?.canvasWidth || this.canvas.height !== this.dimensions.canvasHeight) {
-      this.canvas.width = this.dimensions?.canvasWidth || 0;
-      this.canvas.height = this.dimensions?.canvasHeight || 0;
+    if (this.canvas.width !== this.dimensions!.css.canvas.width || this.canvas.height !== this.dimensions!.css.canvas.height) {
+      this.canvas.width = this.dimensions!.css.canvas.width || 0;
+      this.canvas.height = this.dimensions!.css.canvas.height || 0;
     }
   }
 
@@ -305,7 +305,7 @@ export class ImageRenderer implements IDisposable {
   }
 
   private _insertLayerToDom(): void {
-    this.canvas = ImageRenderer.createCanvas(this._terminal._core._coreBrowserService.window, this.dimensions?.canvasWidth || 0, this.dimensions?.canvasHeight || 0);
+    this.canvas = ImageRenderer.createCanvas(this._terminal._core._coreBrowserService.window, this.dimensions?.css.canvas.width || 0, this.dimensions?.css.canvas.height || 0);
     this.canvas.classList.add('xterm-image-layer');
     this._terminal._core.screenElement?.appendChild(this.canvas);
     this._ctx = this.canvas.getContext('2d', { alpha: true, desynchronized: true });

--- a/src/ImageStorage.ts
+++ b/src/ImageStorage.ts
@@ -234,13 +234,12 @@ export class ImageStorage implements IDisposable {
     let tileCount = 0;
 
     if (!this._opts.sixelScrolling) {
-      this._terminal._core._dirtyRowService.markAllDirty();
       buffer.x = 0;
       buffer.y = 0;
       offset = 0;
     }
 
-    // TODO: how to go with origin mode / scroll margins here?
+    this._terminal._core._inputHandler._dirtyRowTracker.markDirty(buffer.y);
     for (let row = 0; row < rows; ++row) {
       const line = buffer.lines.get(buffer.y + buffer.ybase);
       for (let col = 0; col < cols; ++col) {
@@ -255,6 +254,7 @@ export class ImageStorage implements IDisposable {
       }
       buffer.x = offset;
     }
+    this._terminal._core._inputHandler._dirtyRowTracker.markDirty(buffer.y);
 
     // cursor positioning modes
     if (this._opts.sixelScrolling) {

--- a/src/SixelHandler.ts
+++ b/src/SixelHandler.ts
@@ -4,7 +4,7 @@
  */
 
 import { ImageStorage } from './ImageStorage';
-import { IDcsHandler, IParams, IImageAddonOptions, ITerminalExt, AttributeData, IColorManager, IResetHandler } from './Types';
+import { IDcsHandler, IParams, IImageAddonOptions, ITerminalExt, AttributeData, IResetHandler, ReadonlyColorSet } from './Types';
 import { toRGBA8888, BIG_ENDIAN, PALETTE_ANSI_256, PALETTE_VT340_COLOR } from 'sixel/lib/Colors';
 import { RGBA8888 } from 'sixel/lib/Types';
 import { ImageRenderer } from './ImageRenderer';
@@ -57,7 +57,7 @@ export class SixelHandler implements IDcsHandler, IResetHandler {
     if (this._dec) {
       const fillColor = params.params[1] === 1 ? 0 : extractActiveBg(
         this._coreTerminal._core._inputHandler._curAttrData,
-        this._coreTerminal._core._colorManager.colors);
+        this._coreTerminal._core._themeService.colors);
       this._dec.init(fillColor, null, this._opts.sixelPaletteLimit);
     }
   }
@@ -115,7 +115,7 @@ export class SixelHandler implements IDcsHandler, IResetHandler {
 
 // get currently active background color from terminal
 // also respect INVERSE setting
-function extractActiveBg(attr: AttributeData, colors: IColorManager['colors']): RGBA8888 {
+function extractActiveBg(attr: AttributeData, colors: ReadonlyColorSet): RGBA8888 {
   let bg = 0;
   if (attr.isInverse()) {
     if (attr.isFgDefault()) {

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -10,10 +10,9 @@ import { Attributes, BgFlags, Content, ExtFlags, UnderlineStyle } from 'common/b
 import type { AttributeData } from 'common/buffer/AttributeData';
 import type { IParams, IDcsHandler, IEscapeSequenceParser } from 'common/parser/Types';
 import type { IBufferLine, IExtendedAttrs, IInputHandler } from 'common/Types';
-import type { IDirtyRowService } from 'common/services/Services';
-import type { IColorManager, ITerminal } from 'browser/Types';
-import type { IRenderDimensions } from 'browser/renderer/Types';
-import type { ICoreBrowserService, IRenderService } from 'browser/services/Services';
+import type { ITerminal, ReadonlyColorSet } from 'browser/Types';
+import type { IRenderDimensions } from 'browser/renderer/shared/Types';
+import type { ICoreBrowserService, IRenderService, IThemeService } from 'browser/services/Services';
 
 export const enum Cell {
   CONTENT = 0,  // codepoint and wcwidth information (enum Content)
@@ -23,7 +22,7 @@ export const enum Cell {
 }
 
 // export some privates for local usage
-export { AttributeData, IParams, IDcsHandler, BgFlags, IRenderDimensions, IRenderService, IColorManager, Content, ExtFlags, Attributes, UnderlineStyle };
+export { AttributeData, IParams, IDcsHandler, BgFlags, IRenderDimensions, IRenderService, Content, ExtFlags, Attributes, UnderlineStyle, ReadonlyColorSet };
 
 /**
  * Plugin ctor options.
@@ -67,12 +66,16 @@ export interface IBufferLineExt extends IBufferLine {
 interface IInputHandlerExt extends IInputHandler {
   _parser: IEscapeSequenceParser;
   _curAttrData: AttributeData;
+  _dirtyRowTracker: {
+    markRangeDirty(y1: number, y2: number): void;
+    markAllDirty(): void;
+    markDirty(y: number): void;
+  };
   onRequestReset(handler: () => void): IDisposable;
 }
 
 export interface ICoreTerminalExt extends ITerminal {
-  _dirtyRowService: IDirtyRowService;
-  _colorManager: IColorManager;
+  _themeService: IThemeService;
   _inputHandler: IInputHandlerExt;
   _renderService: IRenderService;
   _coreBrowserService: ICoreBrowserService;

--- a/test/ImageAddon.api.ts
+++ b/test/ImageAddon.api.ts
@@ -83,12 +83,12 @@ describe.only('ImageAddon', () => {
     // terminal privates
     const accessors = [
       '_core',
-      '_core._dirtyRowService',
       '_core._renderService',
       '_core._inputHandler',
       '_core._inputHandler._parser',
       '_core._inputHandler._curAttrData',
-      '_core._colorManager',
+      '_core._inputHandler._dirtyRowTracker',
+      '_core._themeService.colors',
       '_core._coreBrowserService'
     ];
     for (const prop of accessors) {
@@ -247,10 +247,10 @@ describe.only('ImageAddon', () => {
 async function getDimensions(): Promise<IDimensions> {
   const dimensions: any = await page.evaluate(`term._core._renderService.dimensions`);
   return {
-    cellWidth: Math.round(dimensions.actualCellWidth),
-    cellHeight: Math.round(dimensions.actualCellHeight),
-    width: Math.round(dimensions.canvasWidth),
-    height: Math.round(dimensions.canvasHeight)
+    cellWidth: Math.round(dimensions.css.cell.width),
+    cellHeight: Math.round(dimensions.css.cell.height),
+    width: Math.round(dimensions.css.canvas.width),
+    height: Math.round(dimensions.css.canvas.height)
   };
 }
 


### PR DESCRIPTION
Prepare for upcoming 5.1 changes in xterm.js.

TODO, once 5.1.0 is released:
- [ ] change XTERMJS var to 5.1.0
- [ ] new 0.3.1 release (+ readme changes)